### PR TITLE
Fix background-image css syntax

### DIFF
--- a/ocean_blue/css/common.css
+++ b/ocean_blue/css/common.css
@@ -59,7 +59,7 @@ ul {
 /** Social Button Styles **/
 #SignInWithLogonNameExchange {
   background-color: #296ec6;
-  background-image: url(none);
+  background-image: none;
   background-size: 10%;
   background-position-x: 95%;
   background-position-y: 50%;

--- a/slate_gray/css/common.css
+++ b/slate_gray/css/common.css
@@ -50,7 +50,7 @@ ul {
 /** Social Button Styles **/
 #SignInWithLogonNameExchange {
   background-color: #296ec6;
-  background-image: url(none);
+  background-image: none;
   background-size: 10%;
   background-position-x: 95%;
   background-position-y: 50%;


### PR DESCRIPTION
## Purpose
* Fix background-image css syntax in `common.css` file of both `ocean_blue` and `slate_gray` template
* Fixes #9 

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
